### PR TITLE
Add public ip to template file

### DIFF
--- a/provision/kubernetes/kubernetes.tf
+++ b/provision/kubernetes/kubernetes.tf
@@ -95,7 +95,7 @@ resource "openstack_compute_floatingip_associate_v2" "floatip_1" {
   }
 
   provisioner "local-exec" {
-    command = "${var.path}/prepare_template ${openstack_compute_instance_v2.basic.network.0.fixed_ip_v4} ${var.routerip} ${var.path}"
+    command = "${var.path}/prepare_template ${openstack_compute_instance_v2.basic.network.0.fixed_ip_v4} ${openstack_networking_floatingip_v2.floatip_1.address} ${var.routerip} ${var.path}"
   }
 
   provisioner "file" {

--- a/provision/openstack/openstack.tf
+++ b/provision/openstack/openstack.tf
@@ -140,7 +140,7 @@ resource "openstack_compute_floatingip_associate_v2" "floatip_1" {
   }
 
   provisioner "local-exec" {
-    command = "${var.path}/prepare_template ${openstack_compute_instance_v2.basic.network.0.fixed_ip_v4} ${var.routerip} ${var.path}"
+    command = "${var.path}/prepare_template ${openstack_compute_instance_v2.basic.network.0.fixed_ip_v4} ${openstack_networking_floatingip_v2.floatip_1.address} ${var.routerip} ${var.path}"
   }
 
   provisioner "file" {

--- a/provision/prepare_template
+++ b/provision/prepare_template
@@ -1,3 +1,11 @@
 #!/bin/bash
-sed  -i "s|@localip|$1|g" "$3/instances.yaml"
-sed  -i "s|@routerip|$2|g" "$3/instances.yaml"
+
+LocalIP=$1
+PublicIP=$2
+RouterIP=$3
+
+InstancesFile="$4/instances.yaml"
+
+sed -i "s|@localip|$LocalIP|g" "$InstancesFile"
+sed -i "s|@publicip|$PublicIP|g" "$InstancesFile"
+sed -i "s|@routerip|$RouterIP|g" "$InstancesFile"


### PR DESCRIPTION
Public IP is helpful for specific configuration of OpenStack Neutron.
For example public IP is needed upfront for vnc server proxy client.

Can be configured in instances.yaml like this:

```yaml
kolla_config:
  customize:
    neutron.conf: |
      [DEFAULT]
      VNCSERVER_LISTEN=0.0.0.0
      VNCSERVER_PROXYCLIENT_ADDRESS=@publicip
      NOVNCPROXY_URL="http://@publicip:6080/vnc_auto.html"
```